### PR TITLE
Replace AppInfo with StaticAppInfo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app_dirs"
-version = "1.1.1"
+version = "1.2.0"
 authors = ["Andy Barron <AndrewLBarron@gmail.com>"]
 
 description = "Put your app's data in the right place on every platform"

--- a/src/common.rs
+++ b/src/common.rs
@@ -5,8 +5,8 @@ use std;
 /// It's recommended to create a single `const` instance of `AppInfo`:
 ///
 /// ```
-/// use app_dirs::AppInfo;
-/// const APP_INFO: AppInfo = AppInfo{name: "Awesome App", author: "Dedicated Dev"};
+/// use app_dirs::StaticAppInfo;
+/// const APP_INFO: StaticAppInfo = StaticAppInfo{name: "Awesome App", author: "Dedicated Dev"};
 /// ```
 ///
 /// # Caveats
@@ -18,12 +18,16 @@ use std;
 /// The `author` property is currently only used by Windows, as macOS and *nix
 /// specifications don't require it. Make sure your `name` string is unique!
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub struct AppInfo {
+pub struct StaticAppInfo {
     /// Name of your app (e.g. "Hearthstone").
     pub name: &'static str,
     /// Author of your app (e.g. "Blizzard").
     pub author: &'static str,
 }
+
+/// Old name for `StaticAppInfo`. `AppInfo` is deprecated.
+#[deprecated(since = "1.2.0", note = "Use StaticAppInfo instead")]
+pub type AppInfo = StaticAppInfo;
 
 /// A version of AppInfo that owns it's strings
 /// The `author` property is currently only used by Windows, as macOS and *nix

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
 //! extern crate app_dirs;
 //! use app_dirs::*;
 //!
-//! const APP_INFO: AppInfo = AppInfo{name: "CoolApp", author: "SuperDev"};
+//! const APP_INFO: StaticAppInfo = StaticAppInfo{name: "CoolApp", author: "SuperDev"};
 //!
 //! fn main () {
 //!     // Where should I store my app's per-user configuration data?


### PR DESCRIPTION
Renamed AppInfo to StaticAppInfo, added type declaration for AppInfo and marked as deprecated